### PR TITLE
Fix cursor icon path separator on Linux

### DIFF
--- a/pynt v3.py
+++ b/pynt v3.py
@@ -6,7 +6,7 @@ import random
 pygame.init()
 canvas = pygame.Surface((640-84, 400))
 screen = pygame.display.set_mode((640,480))
-cursor = pygame.image.load('gfx\curs.png')
+cursor = pygame.image.load('gfx/curs.png')
 
 #loading up all of the UI GFX
 brush_sml = pygame.image.load('gfx/brush_small.png')


### PR DESCRIPTION
The cursor image is loaded with `gfx\curs.png`. All other images are loaded with `gfx/image_name.png`. The usage of a \ instead of a / made the app crash on startup on my machine (Fedora 42, Python 3.13.5).